### PR TITLE
E2 protection

### DIFF
--- a/lua/autorun/client/cl_nadmodpp.lua
+++ b/lua/autorun/client/cl_nadmodpp.lua
@@ -61,7 +61,7 @@ function NADMOD.PlayerCanTouch(ply, ent)
 		return true
 	end
 	-- Admins can touch anyones props + world
-	if NADMOD.PPConfig["adminall"] and NADMOD.IsPPAdmin(ply) then
+	if NADMOD.PPConfig["adminall"] and NADMOD.IsPPAdmin(ply) and ent:GetClass() ~= "gmod_wire_expression2" then
 		return true
 	end
 	-- Players can touch their own props

--- a/lua/autorun/server/nadmod_pp.lua
+++ b/lua/autorun/server/nadmod_pp.lua
@@ -246,7 +246,7 @@ function NADMOD.PlayerCanTouch(ply, ent)
 		return true
 	end
 	-- Admins can touch anyones props + world
-	if NADMOD.PPConfig["adminall"] and NADMOD.IsPPAdmin(ply) then
+	if NADMOD.PPConfig["adminall"] and NADMOD.IsPPAdmin(ply) and ent:GetClass() ~= "gmod_wire_expression2" then
 		return true
 	end
 	-- Players can touch their own props and friends


### PR DESCRIPTION
# NadmodPP: Expression2 Protection
Limits the permissions of admins, preventing them from bypassing e2request when accessing an expression2.
## Why
- Admins currently have the permissions to open/duplicate other players' expression2s via propprotection.
- Grants players proper control over who can view their expression2s.