### PR TITLE
Remove IsAdmin check from CDP

### DIFF
--- a/lua/autorun/server/nadmod_pp.lua
+++ b/lua/autorun/server/nadmod_pp.lua
@@ -562,10 +562,7 @@ function NADMOD.CleanName(ply, _cmd, _args, fullstr)
 end
 concommand.Add("nadmod_cleanname", NADMOD.CleanName)
 
-function NADMOD.CDP(ply, _cmd, _args)
-	if ply:IsValid() and not NADMOD.IsPPAdmin(ply) then
-		return
-	end
+function NADMOD.CDP(_ply, _cmd, _args)
 	local count = 0
 	for _, v in pairs(NADMOD.Props) do
 		if not v.Ent:IsValid() then


### PR DESCRIPTION
<!--
PR pre-flight checks:
- Have you tested your changes in-game, and using srcds? (either locally hosted or remote)
- Have you done a brief self-review of your changes to check if you've missed anything?
- If working on an issue with defined scope and/or acceptance criteria, have you checked that you've hit everything?
  - If you intentionally haven't followed the issue's requirements, please describe which requirements haven't been hit and why
-->

## Issue

No issue #. User complaints in GMod.

## Changes

- Removes the `IsAdmin` check from the cleanup disconnected players function, allowing all players to use it

## Impact

- Fixes the `!cleanupdiscon` command for users without admin

## Testing

Given the minor change and the significant user impact, I don't think it's worth delaying with a QA

## Helpful Links

[Discord](https://discord.tasevers.com)
