### PR TITLE
Refactor nadmod_ppfriends to not use ReadTable

### DIFF
--- a/lua/autorun/client/cl_nadmodpp.lua
+++ b/lua/autorun/client/cl_nadmodpp.lua
@@ -296,11 +296,24 @@ net.Receive("nadmod_ppfriends", function()
 end)
 
 concommand.Add("npp_applyfriends", function()
+	local networkableFriends = {}
 	for _, tar in pairs(player.GetAll()) do
-		NADMOD.Friends[tar:SteamID()] = GetConVar("npp_friend_" .. tar:SteamID64bot()):GetBool()
+		local steamId = tar:SteamID()
+		local isFriendConVar = GetConVar("npp_friend_" .. tar:SteamID64bot())
+		local isFriend = isFriendConVar and isFriendConVar:GetBool()
+
+		NADMOD.Friends[steamId] = isFriend
+
+		if isFriend then
+			table.insert(networkableFriends, steamId)
+		end
 	end
+
 	net.Start("nadmod_ppfriends")
-	net.WriteTable(NADMOD.Friends)
+	net.WriteUInt(#networkableFriends, 8)
+	for _, friendSteamId in ipairs(networkableFriends) do
+		net.WriteString(friendSteamId)
+	end
 	net.SendToServer()
 end)
 


### PR DESCRIPTION
## Issue

No issue

## Changes

- Rewrites the client -> server `nadmod_ppfriends` flow to not use `net.ReadTable`

## Impact

- Should fix a crash where an invalid type ID is spammed by a client
- Significantly lower network footprint and easier to understand logic

## Testing

- No regressions to friends behaviour
- Spamming a malformed `nadmod_ppfriends` netmsg does not crash the server
  - I haven't had time to test this myself. Assuming net overflow limits kick in this should be fine

## Helpful Links

[Discord](https://discord.tasevers.com)
